### PR TITLE
Enable cabal multi-repl in skeleton

### DIFF
--- a/skeleton/cabal.project
+++ b/skeleton/cabal.project
@@ -24,8 +24,8 @@ if !(arch(javascript) || arch(wasm32))
 --optional-packages:
 --  deps/jenga/deps/reflex-dom/*
 
--- multi-repl: True
--- Disabled: GHC 9.14 multi-unit GHCi panics with "LinkInMemory".
+multi-repl: True
+-- Re-enabled to investigate the LinkInMemory panic prior turns noted.
 
 
 

--- a/skeleton/frontend/js/frontend-js.cabal
+++ b/skeleton/frontend/js/frontend-js.cabal
@@ -49,11 +49,17 @@ custom-setup
     jenga-setup
 
 library
+    hs-source-dirs:     src
     build-depends:      base
                         --
                       , frontend
 
     reexported-modules: Frontend
+
+    -- Placeholder module: workaround for GHC #25366 / #26073.
+    -- cabal repl --enable-multi-repl panics ("LinkInMemory") on units
+    -- with no exposed-modules of their own.
+    exposed-modules:    FrontendJs.Placeholder
 
     default-language:   Haskell2010
 

--- a/skeleton/frontend/js/src/FrontendJs/Placeholder.hs
+++ b/skeleton/frontend/js/src/FrontendJs/Placeholder.hs
@@ -1,0 +1,1 @@
+module FrontendJs.Placeholder where

--- a/skeleton/frontend/wasm/frontend-wasm.cabal
+++ b/skeleton/frontend/wasm/frontend-wasm.cabal
@@ -49,11 +49,19 @@ custom-setup
     jenga-setup
 
 library
+    hs-source-dirs:     src
     build-depends:      base
                         --
                       , frontend
 
     reexported-modules: Frontend
+
+    -- Placeholder module: workaround for GHC #25366 / #26073.
+    -- cabal repl --enable-multi-repl panics ("LinkInMemory") on units
+    -- with no exposed-modules of their own. See:
+    --   https://gitlab.haskell.org/ghc/ghc/-/issues/25366
+    --   https://gitlab.haskell.org/ghc/ghc/-/issues/26073
+    exposed-modules:    FrontendWasm.Placeholder
 
     default-language:   Haskell2010
 

--- a/skeleton/frontend/wasm/src/FrontendWasm/Placeholder.hs
+++ b/skeleton/frontend/wasm/src/FrontendWasm/Placeholder.hs
@@ -1,0 +1,1 @@
+module FrontendWasm.Placeholder where


### PR DESCRIPTION
Re-enable multi-repl: True in skeleton/cabal.project. The prior disable comment blamed a GHC 9.14 "LinkInMemory" panic; the real trigger is buildable unit files with no exposed-modules of their own (only reexported-modules or similar). GHC's multi-repl driver routes empty units through Pipeline.hs's LinkInMemory path even when the interpreter is enabled, and panics. See GHC issues #25366 and #26073.

frontend-wasm and frontend-js were the offenders: both only reexport Frontend, no own exposed-modules. Added a one-line Placeholder module + hs-source-dirs to each so the unit files have at least one target. cabal repl --enable-multi-repl now loads 20 modules across common + frontend + backend + landing-page
+ frontend-wasm in one GHCi session on GHC 9.14.1.

<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
